### PR TITLE
Add support for the L-TEK Dance Pad PRO (DDR pad)

### DIFF
--- a/dist/config/sys-con/config.ini
+++ b/dist/config/sys-con/config.ini
@@ -1424,3 +1424,10 @@ profile=xbox360
 
 [2f24-0050]
 profile=xbox360
+
+[03eb-8041] ;L-TEK Dance Pad PRO
+dpad_left=1
+dpad_right=2
+dpad_up=3
+dpad_down=4
+a=11


### PR DESCRIPTION
Maps directional buttons to d-pad and start/confirmation button to A (start would likely be less useful in most circumstances).