### PR TITLE
Fix sleep/shutdown crash (stack overflow)

### DIFF
--- a/source/Sysmodule/source/psc_module.cpp
+++ b/source/Sysmodule/source/psc_module.cpp
@@ -15,7 +15,11 @@ namespace syscon::psc
         // Thread to check for psc:pm state change (console waking up/going to sleep)
         void PscThreadFunc(void *arg);
 
-        alignas(0x1000) u8 psc_thread_stack[0x1000];
+        // Must be large enough for controllers::Clear()'s teardown on sleep/shutdown: destructor
+        // chains through every connected controller plus several Log*() calls, each driving
+        // newlib's stack-heavy vsnprintf internals. 0x1000 was observed to overflow (crash report
+        // showed SP sitting exactly at the stack region's floor) - sized to match the USB threads.
+        alignas(0x1000) u8 psc_thread_stack[0x4000];
         Thread g_psc_thread;
 
         bool is_psc_thread_running = false;


### PR DESCRIPTION
# Fix sleep/shutdown crash (stack overflow)

## Summary

- **Stack overflow on sleep/shutdown**: `psc_thread_stack` was `0x1000` (4KB), sized back in 2020
  (`3dfa505`) when `PscThreadFunc` barely did anything. It's since become the thread that runs
  `controllers::Clear()` on every sleep/shutdown transition - tearing down each connected
  controller's full destructor chain plus several `Log*()` calls, each driving newlib's
  stack-heavy `vsnprintf` internals. A real Atmosphère crash report (Data Abort, null fault
  address) showed `SP` sitting exactly at the floor of the stack region - the signature of a
  stack overflow into the guard page, not a dangling pointer. Bumped to `0x4000` to match the
  USB threads, which already need similar headroom for the same reason.

  This is a distinct bug from the use-after-teardown fix already merged in #99 - that one was a
  real bug but wasn't sufficient on its own to stop the crash, since it left the actual stack size
  untouched.

## Testing

- Rebuilt from a clean checkout of the exact commit that was flashed at crash time, resolved the
  crash report's addresses with `addr2line`, and confirmed the trace runs through
  `PscThreadFunc` -> `controllers::Clear()` -> `~SwitchHDLHandler()` -> `Exit()` -> `LogInfo` ->
  `vsnprintf`, with `SP` at the stack region's exact floor.
- `ctest --test-dir build` passes all 5 `Configuration.*` tests after the test fix.
- Will soak-test a few sleep/wake cycles on hardware with a controller connected before merge.
