### PR TITLE
Retro-bit SEGA Saturn wireless controller support

### DIFF
--- a/dist/config/sys-con/config.ini
+++ b/dist/config/sys-con/config.ini
@@ -449,6 +449,28 @@ home=13
 lstick_click=11
 rstick_click=12
 
+#[0f0d-00c1] ;Retro-bit SEGA Saturn Wireless 8-Button Arcade Pad V1, USB RF receiver
+#;Preserves correct Mega Drive 6-button layout in Nintendo Switch Online Mega Drive
+#;Keeps NSO suspend menu accessible via Saturn L+R
+#;Provides a sensible default for NSO SNES/GBA/GB/NES without per-game remapping:
+#;              X
+#;  Switch    Y   A     becomes Saturn    L  X  R
+#;              B                        Y   B   A
+#b=2
+#a=8
+#x=1
+#y=3
+#l=4
+#r=7
+#zl=5
+#zr=6
+#minus=9
+#plus=10
+#capture=14
+#home=13
+#lstick_click=11
+#rstick_click=12
+
 #[0f0d-00c1] ; KIWITATA N64 USB Mini Controller
 #a=3,10
 #l=5

--- a/tests/test_configuration.cpp
+++ b/tests/test_configuration.cpp
@@ -86,21 +86,12 @@ TEST(Configuration, test_load_config_adaptoid_n64)
     EXPECT_EQ(config.buttonsPin[ControllerButton::RSTICK_LEFT][0], 5);
     EXPECT_EQ(config.buttonsPin[ControllerButton::RSTICK_RIGHT][0], 3);
 
-    // simulate_capture/simulate_home come from [default] (minus+dpad_up/down) but never actually
-    // fire for this pad, since our simulated minus (below) is resolved after those two combos are
-    // checked in the same frame - this section adds its own direct combos for minus and home instead.
+    // simulate_capture/simulate_home come from [default] (minus+dpad_up/down). This pad has no
+    // Adaptoid-specific combos of its own (tried L+dpad chords for minus/home/zr, but removed them -
+    // personal taste, and they collided with in-game L+D-pad use).
     EXPECT_EQ(config.simulateCombos[0].buttonSimulated, ControllerButton::CAPTURE);
     EXPECT_EQ(config.simulateCombos[1].buttonSimulated, ControllerButton::HOME);
-    EXPECT_EQ(config.simulateCombos[2].buttonSimulated, ControllerButton::MINUS);
-    EXPECT_EQ(config.simulateCombos[2].buttons[0], ControllerButton::L);
-    EXPECT_EQ(config.simulateCombos[2].buttons[1], ControllerButton::DPAD_LEFT);
-    EXPECT_EQ(config.simulateCombos[3].buttonSimulated, ControllerButton::HOME);
-    EXPECT_EQ(config.simulateCombos[3].buttons[0], ControllerButton::L);
-    EXPECT_EQ(config.simulateCombos[3].buttons[1], ControllerButton::DPAD_RIGHT);
-    // A real N64 pad has no ZR either, but ZL+ZR brings up the menu in NSO NES Classics
-    EXPECT_EQ(config.simulateCombos[4].buttonSimulated, ControllerButton::ZR);
-    EXPECT_EQ(config.simulateCombos[4].buttons[0], ControllerButton::L);
-    EXPECT_EQ(config.simulateCombos[4].buttons[1], ControllerButton::DPAD_DOWN);
+    EXPECT_EQ(config.simulateCombos[2].buttonSimulated, ControllerButton::NONE);
 }
 
 TEST(Configuration, test_load_config_with_profile_wii)


### PR DESCRIPTION
- **Fix CI regression from #99**: `test_load_config_adaptoid_n64` still asserted the
  `simulate_minus`/`simulate_home`/`simulate_zr` combos that `config.ini` no longer defines for
  the Adaptoid (removed in #99 as personal taste / to avoid an in-game L+D-pad collision), so the
  test was failing on `master` post-merge. Updated the test to match the current config.

- **Added support for Retro-bit SEGA Saturn Wireless 8-Button Arcade Pad V1 USB RF receiver**. All 6 face buttons behave as physically labelled when playing Switch Online Mega Drive. This profile remains commented out though, since its USB vendor/device ID collides with a Hori battlepad. https://retro-bit.com/sitepad-data/uploads/2025/07/EU-Saturn-2.4-GHz-Manual_102319.pdf